### PR TITLE
Proof of concept Vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "lazygray/heroku-cedar-14"
+  config.vm.box_url = "https://atlas.hashicorp.com/lazygray/boxes/heroku-cedar-14"
+
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+    config.cache.synced_folder_opts = {
+      type: :nfs,
+      mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
+    }
+  end
+
+  # Required for NFS
+  config.vm.network :private_network, ip: "192.168.77.77"
+
+  config.vm.network :forwarded_port, guest: 7007, host: 7007
+  config.ssh.forward_agent = true
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 4096
+    v.cpus = 8
+  end
+
+  config.vm.provision "shell", path: "provision", privileged: false
+end

--- a/provision
+++ b/provision
@@ -1,0 +1,40 @@
+sudo apt-get update
+
+# libpq-dev, python-dev: necessary for compiling C extensions
+sudo apt-get install -y \
+  git-core \
+  htop \
+  libcurl4-gnutls-dev \
+  libpq-dev \
+  libxml2-dev \
+  libxslt-dev \
+  libssl-dev \
+  python-dev \
+  python-pip
+
+sudo pip install memory_profiler \
+                 virtualenv
+
+# create a virtual environment for the project
+cd ~
+rm -rf venv # in case there's an old one lying around
+virtualenv venv
+
+# TODO: install deps to the virtual env
+# source venv/bin/activate
+# cd /vagrant
+# pip install -r dev_requirements.txt
+
+# TODO: later
+# echo 'source /vagrant/scripts/env.sh' >> ~/.bash_profile
+# source /vagrant/scripts/env.sh
+
+#
+## Database
+#
+
+sudo -u postgres psql -c "CREATE USER oee WITH PASSWORD 'oee' SUPERUSER;"
+sudo -u postgres createdb oee
+
+# Jump right into the dev DB CLI with `psql`
+echo 'alias psql="sudo -u postgres psql oee"' >> ~/.bash_profile


### PR DESCRIPTION
More notes later. For now...

Vanilla install of dev env doesn't seem to work. Numpy compilation fails for some reason. Also there are some missing steps in the directions (e.g. assumes virtualenvwrapper is installed)

In past projects, have worked to encapsulating a full dev environment in Vagrant. The setup below allows you to do a `vagrant up` then `vagrant ssh`, and immediately run the tests. (Well, sort of...I need to clean the script up a little, but it's close.)

The benefit beyond a single command for initial set up is that it unifies dev boxes across the org. No more asking "what version of python do you have installed?", since it's scripted in the provision of the Vagrant box.

Possible to do this with Docker instead of Vagrant. Also possible to use Docker as a driver for Vagrant.

Also seems worth considering where to create Vagrantfiles. One in this repo? One for the base level dev environment that you can install multiple OEE components into? Others?
