### PR TITLE
Correct resampling of estimated timeseries

### DIFF
--- a/eemeter/consumption.py
+++ b/eemeter/consumption.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 from warnings import warn
 import pytz
+import copy
 
 from eemeter.evaluation import Period
 
@@ -790,3 +791,34 @@ class ConsumptionData(object):
                 self.unit_name)
         string += self.data.__repr__()
         return string
+
+    def downsample(self, freq):
+
+        # empty case
+        if self.data.shape[0] == 0:
+            return copy.deepcopy(self)
+
+        rng = pd.date_range('2011-01-01', periods=2, freq=freq)
+        target_period = rng[1] - rng[0]
+
+        index_series = pd.Series(self.data.index.tz_convert(pytz.UTC))
+
+        # are there any periods that would require a downsample?
+        if index_series.shape[0] > 2:
+            timedeltas = (index_series - index_series.shift())
+
+            for timedelta in timedeltas:
+                if timedelta < target_period:
+
+                    # Found a short period. Need to resample.
+                    consumption_resampled = ConsumptionData([],
+                            self.fuel_type, self.unit_name,
+                            record_type="arbitrary")
+                    consumption_resampled.data = self.data.resample(freq).sum()
+                    consumption_resampled.estimated = self.estimated.resample(freq).median().astype(bool)
+                    return consumption_resampled
+
+        # Periods are all greater than or equal to downsample target, so just
+        # return copy of self.
+        return copy.deepcopy(self)
+

--- a/eemeter/meter/base.py
+++ b/eemeter/meter/base.py
@@ -208,8 +208,27 @@ class DataCollection:
 
     def __repr__(self):
         string = "DataCollection ({} items)".format(self.count())
+
+        # collect raw strings
+        item_names, item_values, item_tags = [], [], []
         for item in self.iteritems():
-            string += "\n  {:>30}  {:<30} tags={}".format(item.name, item.value, list(item.tags))
+            item_names.append( item.name)
+            item_values.append("\n".join([
+                "    {}".format(l)
+                for l in "{!s}".format(item.value).splitlines()
+            ]))
+            item_tags.append("{}".format(sorted(list(item.tags))))
+
+        # length of longest name will be used for padding
+        max_len = max([len(i) for i in item_names])
+
+        # construct total string
+        for name, value, tags in zip(item_names, item_values, item_tags):
+            line = (
+                "\n{name:-<{padding}}{tags}\n\n{value}\n"
+                .format(name=name, tags=tags, value=value, padding=max_len + 3)
+            )
+            string += line
         return string
 
     def search(self, string, tags=None):

--- a/eemeter/meter/default.py
+++ b/eemeter/meter/default.py
@@ -19,10 +19,10 @@ default_residential_meter_yaml = """
             iterable: { name: consumption },
             meter: !obj:eemeter.meter.Sequence {
                 sequence: [
-                    !obj:eemeter.meter.ResampleConsumption {
+                    !obj:eemeter.meter.DownsampleConsumption {
                         freq: 'D',
                         input_mapping: { consumption_data: {name: consumption_data_raw} },
-                        output_mapping: { consumption_resampled: {name: consumption_data}, },
+                        output_mapping: { consumption_downsampled: {name: consumption_data}, },
                     },
                     !obj:eemeter.meter.BPI_2400_S_2012_ModelCalibrationUtilityBillCriteria {
                         temperature_unit_str: !setting temperature_unit_str,

--- a/tests/fixtures/consumption.py
+++ b/tests/fixtures/consumption.py
@@ -10,7 +10,9 @@ from .weather import gsod_722880_2012_2014_weather_source
 
 from scipy.stats import randint
 
-from datetime import datetime
+from datetime import datetime, timedelta
+import numpy as np
+import pytz
 
 @pytest.fixture
 def consumption_data_1():
@@ -42,6 +44,17 @@ def consumption_data_1():
                 "value": 451}]
     return ConsumptionData(records, "electricity", "kWh",
             record_type="arbitrary_start")
+
+@pytest.fixture
+def consumption_data_15min():
+    records = [{
+        "start": datetime(2015, 1, 1, tzinfo=pytz.UTC) + timedelta(seconds=i*900),
+        "value": np.nan if i % 30 == 0 or 1000 < i < 2000 else 0.1,
+        "estimated": i % 3 == 0 or 2000 < i < 3000,
+    } for i in range(10000)]
+
+    return ConsumptionData(records, "electricity", "kWh", record_type="arbitrary_start")
+
 
 @pytest.fixture(params=[([10, 2, 61, 1, 73], "electricity", "kWh", "degF")])
 def consumption_generator_1(request):
@@ -77,7 +90,7 @@ def consumption_generator_2(request):
     params = model.param_type(params)
     return generator, params
 
-@pytest.fixture(params=[(Period(datetime(2012,1,1),datetime(2014,12,31)),
+@pytest.fixture(params=[(Period(datetime(2012,1,1, tzinfo=pytz.UTC),datetime(2014,12,31, tzinfo=pytz.UTC)),
     randint(30,31))])
 def generated_consumption_data_1(request,
         gsod_722880_2012_2014_weather_source, consumption_generator_1):
@@ -88,7 +101,7 @@ def generated_consumption_data_1(request,
             gsod_722880_2012_2014_weather_source, datetimes)
     return consumption_data, params
 
-@pytest.fixture(params=[(Period(datetime(2012,1,1),datetime(2014,12,31)),randint(30,31))])
+@pytest.fixture(params=[(Period(datetime(2012,1,1, tzinfo=pytz.UTC),datetime(2014,12,31, tzinfo=pytz.UTC)),randint(30,31))])
 def generated_consumption_data_2(request,
         gsod_722880_2012_2014_weather_source, consumption_generator_2):
     period, dist = request.param

--- a/tests/test_meter_library.py
+++ b/tests/test_meter_library.py
@@ -22,6 +22,7 @@ from eemeter.meter import ConsumptionDataAttributes
 from eemeter.meter import ProjectAttributes
 from eemeter.meter import ProjectConsumptionDataBaselineReporting
 from eemeter.meter import ProjectFuelTypes
+from eemeter.meter import DownsampleConsumption
 
 from eemeter.models import AverageDailyTemperatureSensitivityModel
 
@@ -37,6 +38,7 @@ from fixtures.consumption import generated_consumption_data_with_annualized_usag
 from fixtures.consumption import generated_consumption_data_pre_post_with_gross_savings_1
 from fixtures.consumption import generated_consumption_data_pre_post_with_annualized_gross_savings_1
 from fixtures.consumption import consumption_data_1
+from fixtures.consumption import consumption_data_15min
 from fixtures.consumption import time_span_1
 from fixtures.consumption import generated_consumption_data_with_hdd_1
 from fixtures.consumption import generated_consumption_data_with_cdd_1
@@ -329,6 +331,34 @@ def test_estimated_average_daily_usage(generated_consumption_data_1,gsod_722880_
     assert result["estimated_average_daily_usages"] is not None
     assert result["n_days"] is not None
 
+def test_downsample_consumption_data(generated_consumption_data_1, consumption_data_15min):
+    cd, params = generated_consumption_data_1
+
+    meter = DownsampleConsumption(freq="D")
+
+    # monthly frequency - so this won't downsample
+    result = meter.evaluate_raw(consumption_data=cd)
+    cd_down = result["consumption_downsampled"]
+    assert_allclose(cd.data, cd_down.data)
+    assert_allclose(cd.estimated, cd_down.estimated)
+
+
+    # 15min freq - should downsample
+    meter = DownsampleConsumption(freq="H")
+    result = meter.evaluate_raw(consumption_data=consumption_data_15min)
+    cd_down = result["consumption_downsampled"]
+
+    assert consumption_data_15min.data.shape == (10000,)
+    assert consumption_data_15min.estimated.shape == (10000,)
+
+    assert_allclose(cd_down.data["2015-01-01 00:00"], 0.3)
+    assert_allclose(cd_down.data["2015-01-01 01:00"], 0.4)
+    assert cd_down.data.shape == (2500,)
+
+    assert cd_down.estimated["2015-01-01 00:00"] == True
+    assert cd_down.estimated["2015-01-01 01:00"] == False
+    assert cd_down.estimated.shape == (2500,)
+
 def test_consumption_data_attributes(generated_consumption_data_1):
     cd,params = generated_consumption_data_1
     meter = ConsumptionDataAttributes()
@@ -363,12 +393,12 @@ def test_project_consumption_baseline_reporting(generated_consumption_data_1):
     project = Project(location,[cd],baseline_period,reporting_period)
     meter = ProjectConsumptionDataBaselineReporting()
     result = meter.evaluate_raw(project=project)
-    assert result["consumption"][0]["value"].data.index[0] == datetime(2012,1,1)
-    assert result["consumption"][0]["value"].data.index[17] == datetime(2013,5,25)
+    assert result["consumption"][0]["value"].data.index[0] == datetime(2012,1,1, tzinfo=pytz.UTC)
+    assert result["consumption"][0]["value"].data.index[17] == datetime(2013,5,25, tzinfo=pytz.UTC)
     assert result["consumption"][0]["tags"][0] == "electricity"
     assert result["consumption"][0]["tags"][1] == "baseline"
-    assert result["consumption"][1]["value"].data.index[0] == datetime(2013,6,24)
-    assert result["consumption"][1]["value"].data.index[18] == datetime(2014,12,16)
+    assert result["consumption"][1]["value"].data.index[0] == datetime(2013,6,24, tzinfo=pytz.UTC)
+    assert result["consumption"][1]["value"].data.index[18] == datetime(2014,12,16, tzinfo=pytz.UTC)
     assert result["consumption"][1]["tags"][0] == "electricity"
     assert result["consumption"][1]["tags"][1] == "reporting"
 

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -51,5 +51,4 @@ def test_dump_meter():
     assert len(dump(meter.meter)) == 11913
 
     meter = DefaultResidentialMeter("degF")
-    assert len(dump(meter.meter)) == 21655
-
+    assert len(dump(meter.meter)) == 21659


### PR DESCRIPTION
This fixes an issue in which the estimated reading consolidation step for resampled (higher frequency) data was returning empty pandas timeseries, which caused downstream meters to fail with NaN and 0 values. The problem originated in the resample step, in which `consumption_data.data` was resampled, but `consumption_data.estimated` was not resampled, and returned an empty series.
